### PR TITLE
fix(docs): prevent cold-load sidebar shift

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -2,6 +2,7 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
 // Reserve Starlight's final desktop columns before its external stylesheet arrives.
+// Keep these dimensions and equations aligned with global.css and Starlight's main-frame rules.
 const criticalDesktopLayout = String.raw`
   :root {
     --sl-content-width: 56rem;

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from "astro/config";
 // Reserve Starlight's final desktop columns before its external stylesheet arrives.
 // Keep these dimensions and equations aligned with global.css and Starlight's main-frame rules.
 const criticalDesktopLayout = String.raw`
-  :root {
+  :where(:root) {
     --sl-content-width: 56rem;
     --sl-sidebar-width: 18rem;
   }

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -2,14 +2,14 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
 // Reserve Starlight's final desktop columns before its external stylesheet arrives.
-const criticalDesktopLayout = `
+const criticalDesktopLayout = String.raw`
   :root {
     --sl-content-width: 56rem;
     --sl-sidebar-width: 18rem;
   }
 
   @media (min-width: 72rem) {
-    .main-frame > .lg\\:sl-flex {
+    .main-frame > .lg\:sl-flex {
       display: flex;
     }
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -31,6 +31,7 @@ const criticalDesktopLayout = String.raw`
     }
 
     [data-has-sidebar][data-has-toc] .main-pane {
+      --sl-content-margin-inline: auto 0;
       order: 1;
       width: min(
         calc(100% - var(--sl-sidebar-width)),

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,6 +1,47 @@
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
+// Reserve Starlight's final desktop columns before its external stylesheet arrives.
+const criticalDesktopLayout = `
+  :root {
+    --sl-content-width: 56rem;
+    --sl-sidebar-width: 18rem;
+  }
+
+  @media (min-width: 72rem) {
+    .main-frame > .lg\\:sl-flex {
+      display: flex;
+    }
+
+    .right-sidebar-container {
+      order: 2;
+      position: relative;
+      width: max(
+        var(--sl-sidebar-width),
+        calc(
+          var(--sl-sidebar-width) +
+            (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+        )
+      );
+    }
+
+    .main-pane {
+      width: 100%;
+    }
+
+    [data-has-sidebar][data-has-toc] .main-pane {
+      order: 1;
+      width: min(
+        calc(100% - var(--sl-sidebar-width)),
+        calc(
+          var(--sl-content-width) +
+            (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
+        )
+      );
+    }
+  }
+`.trim();
+
 export default defineConfig({
   base: "/likftc",
   prefetch: false,
@@ -19,6 +60,11 @@ export default defineConfig({
       expressiveCode: false,
       favicon: "/favicon.png",
       head: [
+        {
+          tag: "style",
+          attrs: { "data-likftc-critical-layout": true },
+          content: criticalDesktopLayout,
+        },
         {
           tag: "meta",
           attrs: {

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -10,11 +10,11 @@ const criticalDesktopLayout = String.raw`
   }
 
   @media (min-width: 72rem) {
-    .main-frame > .lg\:sl-flex {
+    :where(.main-frame > .lg\:sl-flex) {
       display: flex;
     }
 
-    .right-sidebar-container {
+    :where(.right-sidebar-container) {
       order: 2;
       position: relative;
       width: max(
@@ -26,11 +26,11 @@ const criticalDesktopLayout = String.raw`
       );
     }
 
-    .main-pane {
+    :where(.main-pane) {
       width: 100%;
     }
 
-    [data-has-sidebar][data-has-toc] .main-pane {
+    :where([data-has-sidebar][data-has-toc] .main-pane) {
       --sl-content-margin-inline: auto 0;
       order: 1;
       width: min(


### PR DESCRIPTION
## Summary

- reserve Starlight's final desktop columns before the external stylesheet loads
- prevent the right table-of-contents sidebar from shifting across the viewport on cold loads
- keep the inline dimensions identical to the final branded Starlight layout

## Verification

- `pnpm run check`
- `pnpm run check:docs`
- `LIKFTC_SITE_WIDTH=1440 pnpm run check:site`
- `pnpm run check:site`

## Context

The first `main` CI run after PR #10 observed a cold-load CLS of 0.48 on the Angular Signals page at 1440px. The external stylesheet occasionally arrived after the initial desktop layout, so the right sidebar first occupied the content column and then moved to its final position.
