### PR TITLE
fix(ci): run lint-staged through Vite+

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged --concurrent false
+vp exec lint-staged --concurrent false


### PR DESCRIPTION
## Summary

- run the Husky pre-commit hook through Vite+ instead of relying on a globally available pnpm binary
- keep lint-staged enabled for Changesets release commits

## Verification

- simulated the release runner PATH without pnpm and ran the pre-commit hook successfully
- vp check
- git diff --check

## Context

The main release job passed quality and fresh Node 22/24 consumer checks, then failed only when Changesets committed the generated release PR because pnpm was not present in PATH.