### PR TITLE
fix(docs): stabilize critical desktop layout

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -10,11 +10,11 @@ const criticalDesktopLayout = String.raw`
   }
 
   @media (min-width: 72rem) {
-    html[data-has-toc] .main-frame > .lg\:sl-flex {
+    html .main-frame > .lg\:sl-flex {
       display: flex;
     }
 
-    html[data-has-toc] .right-sidebar-container {
+    html .right-sidebar-container {
       order: 2;
       position: relative;
       width: max(
@@ -26,7 +26,7 @@ const criticalDesktopLayout = String.raw`
       );
     }
 
-    html[data-has-toc] .main-pane {
+    html .main-pane {
       width: 100%;
     }
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -14,6 +14,11 @@ const criticalDesktopLayout = String.raw`
       display: flex;
     }
 
+    /* Prevent partially loaded Starlight chunks from exposing an intermediate column layout. */
+    :where([data-has-toc] .main-frame > .lg\:sl-flex) {
+      visibility: hidden;
+    }
+
     :where(.right-sidebar-container) {
       order: 2;
       position: relative;

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -4,22 +4,17 @@ import { defineConfig } from "astro/config";
 // Reserve Starlight's final desktop columns before its external stylesheet arrives.
 // Keep these dimensions and equations aligned with global.css and Starlight's main-frame rules.
 const criticalDesktopLayout = String.raw`
-  :where(:root) {
+  :root {
     --sl-content-width: 56rem;
     --sl-sidebar-width: 18rem;
   }
 
   @media (min-width: 72rem) {
-    :where(.main-frame > .lg\:sl-flex) {
+    html[data-has-toc] .main-frame > .lg\:sl-flex {
       display: flex;
     }
 
-    /* Prevent partially loaded Starlight chunks from exposing an intermediate column layout. */
-    :where([data-has-toc] .main-frame > .lg\:sl-flex) {
-      visibility: hidden;
-    }
-
-    :where(.right-sidebar-container) {
+    html[data-has-toc] .right-sidebar-container {
       order: 2;
       position: relative;
       width: max(
@@ -31,11 +26,11 @@ const criticalDesktopLayout = String.raw`
       );
     }
 
-    :where(.main-pane) {
+    html[data-has-toc] .main-pane {
       width: 100%;
     }
 
-    :where([data-has-sidebar][data-has-toc] .main-pane) {
+    html[data-has-sidebar][data-has-toc] .main-pane {
       --sl-content-margin-inline: auto 0;
       order: 1;
       width: min(

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -145,6 +145,13 @@ body::before {
   overflow: clip;
 }
 
+@media (min-width: 72rem) {
+  /* Reveal after Starlight and the final column rules have loaded. */
+  [data-has-toc] .main-frame > .lg\:sl-flex {
+    visibility: visible;
+  }
+}
+
 .framework-demo-host {
   display: block;
   margin-block: 1rem;

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -145,13 +145,6 @@ body::before {
   overflow: clip;
 }
 
-@media (min-width: 72rem) {
-  /* Reveal after Starlight and the final column rules have loaded. */
-  [data-has-toc] .main-frame > .lg\:sl-flex {
-    visibility: visible;
-  }
-}
-
 .framework-demo-host {
   display: block;
   margin-block: 1rem;


### PR DESCRIPTION
## Summary

- raise the inline critical desktop selectors above Starlight's scoped `:where()` rules
- keep the final desktop column geometry active while split CSS chunks load
- preserve readable content even if an external stylesheet fails

## Verification

- `vp check`
- Astro build
- 6 consecutive Chromium 1440px matrices across home, all framework guides, all state guides, and standalone demos
- Chromium 320px, 375px, and 1920px matrices
- Firefox 1440px matrix
- WebKit 1440px matrix

## Context

The final publish run exposed a remaining cold-load race on Alien Signals at 1440px: an intermediate Starlight chunk temporarily rendered the right sidebar at full content width, producing CLS 0.48. The previous critical selectors used `:where()`, reducing their specificity to zero, so later scoped rules could override them before the final responsive rules settled.
