### PR TITLE
test(docs): retry transient CLS budgets

### DIFF
--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -353,7 +353,7 @@ async function inspectPageAttempt(baseUrl, path, width, inspect, contextOptions)
     await inspect(page);
     const metrics = await getWebVitals(page);
     const cls = metrics?.cls ?? 0;
-    assert.ok(
+    assertWebVital(
       cls <= 0.1,
       `${path} cumulative layout shift ${cls} exceeds 0.1: ${JSON.stringify(metrics?.clsShifts)}`,
     );


### PR DESCRIPTION
## Summary

Classify cumulative layout shift budget failures as Web Vitals failures so they receive the same single clean-context retry already used for transient FCP, LCP, and event-duration misses.

## Root cause

The stable-preparation PR passed the complete browser matrix, but the following `main` run observed a one-off cold-load Starlight sidebar shift. The retry infrastructure introduced for transient Web Vitals did not cover the shared CLS assertion because it still threw a generic assertion error.

The `0.1` CLS budget is unchanged. A second miss still fails the job.

## Verification

- `vp check`
- `vp run check:site`

Chromium passed six responsive widths across the home page, eight framework demos, nine state demos, and standalone pages.
