### PR TITLE
fix(deps): align Dependabot with release-age policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    # Match pnpm's strict one-day minimum release age without weakening
+    # security updates, which are not subject to Dependabot cooldowns.
+    cooldown:
+      default-days: 1
     ignore:
       # TypeScript versions are coordinated manually across the native TS7
       # checker, the TS6 compatibility alias, and Vue's TS5 SFC checker.


### PR DESCRIPTION
## Summary

- delay Dependabot version updates for one day
- keep pnpm's strict one-day minimum release age enabled
- leave Dependabot security updates immediate

## Root cause

After #22 merged, Dependabot correctly loaded the new ignore policy but failed while updating newly published packages. Dependabot invokes `pnpm update --no-save`; pnpm rejects that command when `minimumReleaseAgeStrict` needs to persist an approval for an immature version.

A one-day Dependabot cooldown prevents the bot from selecting versions that pnpm will reject, while preserving the repository's strict supply-chain policy. GitHub documents that cooldowns apply only to version updates, not security updates.

## Verification

- parsed `.github/dependabot.yml` as YAML
- `git diff --check`
- `vp check`

## Risk

Low. This changes only the timing of automated version-update PRs. Security updates remain unaffected.
