### PR TITLE
fix(docs): remove duplicate header border

### DIFF
--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -117,6 +117,7 @@ body::before {
 }
 
 header.header {
+  -webkit-backdrop-filter: blur(16px);
   backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--brand-line);
 }

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -116,7 +116,7 @@ body::before {
   text-decoration-style: dotted;
 }
 
-.header {
+header.header {
   backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--brand-line);
 }

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1420,25 +1420,25 @@ try {
         assert.equal(await page.locator(`[data-likftc-demo="${framework.demo}"]`).count(), 1);
         if (framework.guide === "react" && width === 1_440) {
           assert.deepEqual(
-            await page.locator(".header").evaluateAll((headers) =>
+            await page.locator("header.header, header.header > .header").evaluateAll((headers) =>
               headers.map((header) => {
                 const style = getComputedStyle(header);
+                const hasBorder =
+                  style.borderBottomStyle !== "none" &&
+                  Number.parseFloat(style.borderBottomWidth) > 0;
                 return {
-                  borderBottomStyle: style.borderBottomStyle,
-                  borderBottomWidth: style.borderBottomWidth,
+                  hasBorder,
                   tagName: header.tagName,
                 };
               }),
             ),
             [
               {
-                borderBottomStyle: "solid",
-                borderBottomWidth: "1px",
+                hasBorder: true,
                 tagName: "HEADER",
               },
               {
-                borderBottomStyle: "none",
-                borderBottomWidth: "0px",
+                hasBorder: false,
                 tagName: "DIV",
               },
             ],

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1423,25 +1423,13 @@ try {
             await page.locator("header.header, header.header > .header").evaluateAll((headers) =>
               headers.map((header) => {
                 const style = getComputedStyle(header);
-                const hasBorder =
+                return (
                   style.borderBottomStyle !== "none" &&
-                  Number.parseFloat(style.borderBottomWidth) > 0;
-                return {
-                  hasBorder,
-                  tagName: header.tagName,
-                };
+                  Number.parseFloat(style.borderBottomWidth) > 0
+                );
               }),
             ),
-            [
-              {
-                hasBorder: true,
-                tagName: "HEADER",
-              },
-              {
-                hasBorder: false,
-                tagName: "DIV",
-              },
-            ],
+            [true, false],
           );
         }
         assert.equal(

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1418,7 +1418,7 @@ try {
         assert.equal(await page.locator("h1").count(), 1);
         assert.equal(await page.locator("iframe").count(), 0);
         assert.equal(await page.locator(`[data-likftc-demo="${framework.demo}"]`).count(), 1);
-        if (framework.guide === "react" && width === 1_440) {
+        if (framework.guide === frameworks[0].guide && width === 1_440) {
           assert.deepEqual(
             await page.locator("header.header, header.header > .header").evaluateAll((headers) =>
               headers.map((header) => {

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1418,6 +1418,32 @@ try {
         assert.equal(await page.locator("h1").count(), 1);
         assert.equal(await page.locator("iframe").count(), 0);
         assert.equal(await page.locator(`[data-likftc-demo="${framework.demo}"]`).count(), 1);
+        if (framework.guide === "react" && width === 1_440) {
+          assert.deepEqual(
+            await page.locator(".header").evaluateAll((headers) =>
+              headers.map((header) => {
+                const style = getComputedStyle(header);
+                return {
+                  borderBottomStyle: style.borderBottomStyle,
+                  borderBottomWidth: style.borderBottomWidth,
+                  tagName: header.tagName,
+                };
+              }),
+            ),
+            [
+              {
+                borderBottomStyle: "solid",
+                borderBottomWidth: "1px",
+                tagName: "HEADER",
+              },
+              {
+                borderBottomStyle: "none",
+                borderBottomWidth: "0px",
+                tagName: "DIV",
+              },
+            ],
+          );
+        }
         assert.equal(
           await page.locator(`script[src="/likftc/demos/${framework.demo}.js"]`).count(),
           1,


### PR DESCRIPTION
## Summary

- scope the branded header border and blur to the outer Starlight `header.header` shell
- add a browser regression assertion that the nested `div.header` has no bottom border

## Verification

- `vp check`
- `vp run check:docs`
- `vp run @vp-tw/likftc-docs#build`
- `LIKFTC_SITE_FRAMEWORK=react LIKFTC_SITE_WIDTH=1440 node scripts/validate-docs.mjs --browser=chromium`

## Risk

Low. The CSS selector is narrowed to the semantic outer header, and the regression test verifies both computed border states.