### PR TITLE
feat(docs): sync hero orbit with beat

### DIFF
--- a/apps/docs/src/components/FilterVortexStage.astro
+++ b/apps/docs/src/components/FilterVortexStage.astro
@@ -25,6 +25,9 @@ import filterVortexStyles from "../styles/filter-vortex-stage.css?raw";
           <div class="tokens" data-tokens aria-hidden="true"></div>
         </div>
       </section>
+      <div class="beat-orbit" aria-hidden="true">
+        <span data-beat-orbit-tone></span>
+      </div>
       <div class="pulse-field" data-pulse-field aria-hidden="true"></div>
       <button class="query-trigger" type="button" data-trigger aria-label="Change search query">
         <span data-trigger-tone aria-hidden="true"></span>
@@ -118,6 +121,7 @@ import filterVortexStyles from "../styles/filter-vortex-stage.css?raw";
     const stage = requireElement<HTMLElement>(shadowRoot, "[data-stage]"),
       space = requireElement<HTMLElement>(stage, "[data-space]"),
       tokens = requireElement<HTMLElement>(stage, "[data-tokens]"),
+      beatOrbitTone = requireElement<HTMLElement>(stage, "[data-beat-orbit-tone]"),
       pulseField = requireElement<HTMLElement>(stage, "[data-pulse-field]"),
       query = requireElement<HTMLElement>(stage, "[data-query]"),
       queryLabel = requireElement<HTMLElement>(stage, ".query-label"),
@@ -146,6 +150,7 @@ import filterVortexStyles from "../styles/filter-vortex-stage.css?raw";
       pointerX = 0.5,
       pointerY = 0.5,
       triggerBeat: Animation | undefined,
+      orbitBeat: Animation | undefined,
       labelShake: Animation | undefined,
       queryEnter: Animation | undefined;
 
@@ -327,8 +332,10 @@ import filterVortexStyles from "../styles/filter-vortex-stage.css?raw";
       const tone = pulseTones[pulseIndex];
       if (tone === undefined) throw new Error(`Missing pulse tone ${pulseIndex}`);
       triggerTone.style.setProperty("--trigger-tone", tone);
+      beatOrbitTone.style.setProperty("--orbit-tone", tone);
       queryLabel.style.setProperty("--label-tone", tone);
       triggerTone.dataset["toneIndex"] = String(pulseIndex);
+      beatOrbitTone.dataset["toneIndex"] = String(pulseIndex);
       queryLabel.dataset["toneIndex"] = String(pulseIndex);
       if (reduced.matches) return;
 
@@ -357,6 +364,18 @@ import filterVortexStyles from "../styles/filter-vortex-stage.css?raw";
             { offset: 1, rotate: "0deg", scale: 1, translate: "0 0" },
           ],
           { duration: 1200, easing: "cubic-bezier(0.16, 1, 0.3, 1)" },
+        ),
+      );
+      orbitBeat?.cancel();
+      orbitBeat = trackAnimation(
+        beatOrbitTone.animate(
+          [
+            { offset: 0, opacity: 0.76, scale: 1 },
+            { offset: 0.22, opacity: 1, scale: 1.018 },
+            { offset: 0.5, opacity: 0.82, scale: 0.994 },
+            { offset: 1, opacity: 0.9, scale: 1 },
+          ],
+          { duration: 560, easing: "cubic-bezier(0.16, 1, 0.3, 1)" },
         ),
       );
       labelShake?.cancel();

--- a/apps/docs/src/components/FilterVortexStage.astro
+++ b/apps/docs/src/components/FilterVortexStage.astro
@@ -370,7 +370,7 @@ import filterVortexStyles from "../styles/filter-vortex-stage.css?raw";
       orbitBeat = trackAnimation(
         beatOrbitTone.animate(
           [
-            { offset: 0, opacity: 0.76, scale: 1 },
+            { offset: 0, opacity: 0.9, scale: 1 },
             { offset: 0.22, opacity: 1, scale: 1.018 },
             { offset: 0.5, opacity: 0.82, scale: 0.994 },
             { offset: 1, opacity: 0.9, scale: 1 },

--- a/apps/docs/src/styles/filter-vortex-stage.css
+++ b/apps/docs/src/styles/filter-vortex-stage.css
@@ -70,6 +70,7 @@ button {
   border-radius: inherit;
   display: block;
   height: 100%;
+  opacity: 0.9;
   transition: border-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
   width: 100%;
 }

--- a/apps/docs/src/styles/filter-vortex-stage.css
+++ b/apps/docs/src/styles/filter-vortex-stage.css
@@ -38,9 +38,8 @@ button {
 }
 
 .stage::before,
-.stage::after {
+.beat-orbit {
   border-radius: 50%;
-  content: "";
   pointer-events: none;
   position: absolute;
 }
@@ -48,6 +47,7 @@ button {
 .stage::before {
   animation: field-breathe 8s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
   border: 1px solid #393934;
+  content: "";
   height: min(76vw, 70rem);
   left: 67%;
   top: 52%;
@@ -55,20 +55,29 @@ button {
   width: min(76vw, 70rem);
 }
 
-.stage::after {
+.beat-orbit {
   animation: field-breathe 5.5s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate-reverse;
-  border: 1px solid var(--blue);
   height: min(48vw, 42rem);
   left: 67%;
   top: 52%;
   translate: -50% -50%;
   width: min(48vw, 42rem);
+  z-index: 2;
+}
+
+.beat-orbit span {
+  border: 1px solid var(--orbit-tone, var(--blue));
+  border-radius: inherit;
+  display: block;
+  height: 100%;
+  transition: border-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  width: 100%;
 }
 
 .stage[data-autoplay="paused"]::before,
-.stage[data-autoplay="paused"]::after,
+.stage[data-autoplay="paused"] .beat-orbit,
 .stage[data-ambient="paused"]::before,
-.stage[data-ambient="paused"]::after {
+.stage[data-ambient="paused"] .beat-orbit {
   animation-play-state: paused;
 }
 
@@ -438,7 +447,7 @@ button {
   }
 
   .stage::before,
-  .stage::after,
+  .beat-orbit,
   .pulse-field,
   .query-trigger {
     left: 50%;
@@ -493,7 +502,8 @@ button {
 
 @media (prefers-reduced-motion: reduce) {
   .stage::before,
-  .stage::after,
+  .beat-orbit,
+  .beat-orbit span,
   .pulse-field i,
   .space,
   .query-trigger span,

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -468,6 +468,26 @@ async function settleHomeHero(page) {
   });
 }
 
+async function readHomeHeroBeatState(hero) {
+  return hero.evaluate((host) => {
+    const root = host.shadowRoot;
+    const orbit = root?.querySelector("[data-beat-orbit-tone]");
+    const trigger = root?.querySelector("[data-trigger-tone]");
+    if (!(orbit instanceof HTMLElement) || !(trigger instanceof HTMLElement)) {
+      throw new Error("Hero beat tone elements are missing");
+    }
+    return {
+      animationDurations: orbit
+        .getAnimations()
+        .map((animation) => animation.effect?.getComputedTiming().duration),
+      orbitTone: orbit.style.getPropertyValue("--orbit-tone"),
+      orbitToneIndex: orbit.dataset["toneIndex"],
+      triggerTone: trigger.style.getPropertyValue("--trigger-tone"),
+      triggerToneIndex: trigger.dataset["toneIndex"],
+    };
+  });
+}
+
 async function waitForInlineDemo(page, demo) {
   const host = page.locator(`[data-likftc-demo="${demo}"]`);
   await host.locator(".runtime-demo[data-playback]").waitFor();
@@ -818,23 +838,7 @@ try {
             .locator("[data-trigger-tone]")
             .getAttribute("data-tone-index");
           await hero.getByRole("button", { name: "Change search query", exact: true }).click();
-          const beatState = await hero.evaluate((host) => {
-            const root = host.shadowRoot;
-            const orbit = root?.querySelector("[data-beat-orbit-tone]");
-            const trigger = root?.querySelector("[data-trigger-tone]");
-            if (!(orbit instanceof HTMLElement) || !(trigger instanceof HTMLElement)) {
-              throw new Error("Hero beat tone elements are missing");
-            }
-            return {
-              animationDurations: orbit
-                .getAnimations()
-                .map((animation) => animation.effect?.getComputedTiming().duration),
-              orbitTone: orbit.style.getPropertyValue("--orbit-tone"),
-              orbitToneIndex: orbit.dataset["toneIndex"],
-              triggerTone: trigger.style.getPropertyValue("--trigger-tone"),
-              triggerToneIndex: trigger.dataset["toneIndex"],
-            };
-          });
+          const beatState = await readHomeHeroBeatState(hero);
           assert.ok(beatState.animationDurations.includes(560));
           assert.equal(beatState.orbitTone, beatState.triggerTone);
           assert.equal(beatState.orbitToneIndex, beatState.triggerToneIndex);
@@ -848,22 +852,8 @@ try {
           await page.emulateMedia({ reducedMotion: "reduce" });
           const hero = page.locator("likftc-filter-vortex-stage");
           await hero.getByRole("button", { name: "Change search query", exact: true }).click();
-          const reducedBeatState = await hero.evaluate((host) => {
-            const root = host.shadowRoot;
-            const orbit = root?.querySelector("[data-beat-orbit-tone]");
-            const trigger = root?.querySelector("[data-trigger-tone]");
-            if (!(orbit instanceof HTMLElement) || !(trigger instanceof HTMLElement)) {
-              throw new Error("Hero beat tone elements are missing");
-            }
-            return {
-              animationCount: orbit.getAnimations().length,
-              orbitTone: orbit.style.getPropertyValue("--orbit-tone"),
-              orbitToneIndex: orbit.dataset["toneIndex"],
-              triggerTone: trigger.style.getPropertyValue("--trigger-tone"),
-              triggerToneIndex: trigger.dataset["toneIndex"],
-            };
-          });
-          assert.equal(reducedBeatState.animationCount, 0);
+          const reducedBeatState = await readHomeHeroBeatState(hero);
+          assert.equal(reducedBeatState.animationDurations.length, 0);
           assert.equal(reducedBeatState.orbitTone, reducedBeatState.triggerTone);
           assert.equal(reducedBeatState.orbitToneIndex, reducedBeatState.triggerToneIndex);
         }

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -479,7 +479,7 @@ async function readHomeHeroBeatState(hero) {
     return {
       animationDurations: orbit
         .getAnimations()
-        .map((animation) => animation.effect?.getComputedTiming().duration),
+        .map((animation) => animation.effect?.getTiming().duration),
       orbitTone: orbit.style.getPropertyValue("--orbit-tone"),
       orbitToneIndex: orbit.dataset["toneIndex"],
       triggerTone: trigger.style.getPropertyValue("--trigger-tone"),

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -856,6 +856,7 @@ try {
           assert.equal(reducedBeatState.animationDurations.length, 0);
           assert.equal(reducedBeatState.orbitTone, reducedBeatState.triggerTone);
           assert.equal(reducedBeatState.orbitToneIndex, reducedBeatState.triggerToneIndex);
+          await page.emulateMedia({ reducedMotion: "no-preference" });
         }
         assert.deepEqual(
           await page.evaluate(() => {

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -445,10 +445,7 @@ async function assertAccessible(page, context) {
 }
 
 async function settleHomeHero(page) {
-  const playbackControl = page.getByRole("button", {
-    name: "Pause automatic animation",
-    exact: true,
-  });
+  const playbackControl = page.locator("likftc-filter-vortex-stage [data-playback-control]");
   if ((await playbackControl.getAttribute("aria-pressed")) === "false") {
     await playbackControl.click();
   }
@@ -815,6 +812,61 @@ try {
       }
       if (width === 320 || width === 1440) {
         await settleHomeHero(page);
+        if (width === 1440) {
+          const hero = page.locator("likftc-filter-vortex-stage");
+          const initialToneIndex = await hero
+            .locator("[data-trigger-tone]")
+            .getAttribute("data-tone-index");
+          await hero.getByRole("button", { name: "Change search query", exact: true }).click();
+          const beatState = await hero.evaluate((host) => {
+            const root = host.shadowRoot;
+            const orbit = root?.querySelector("[data-beat-orbit-tone]");
+            const trigger = root?.querySelector("[data-trigger-tone]");
+            if (!(orbit instanceof HTMLElement) || !(trigger instanceof HTMLElement)) {
+              throw new Error("Hero beat tone elements are missing");
+            }
+            return {
+              animationDurations: orbit
+                .getAnimations()
+                .map((animation) => animation.effect?.getComputedTiming().duration),
+              orbitTone: orbit.style.getPropertyValue("--orbit-tone"),
+              orbitToneIndex: orbit.dataset["toneIndex"],
+              triggerTone: trigger.style.getPropertyValue("--trigger-tone"),
+              triggerToneIndex: trigger.dataset["toneIndex"],
+            };
+          });
+          assert.ok(beatState.animationDurations.includes(560));
+          assert.equal(beatState.orbitTone, beatState.triggerTone);
+          assert.equal(beatState.orbitToneIndex, beatState.triggerToneIndex);
+          assert.notEqual(
+            await hero.locator("[data-trigger-tone]").getAttribute("data-tone-index"),
+            initialToneIndex,
+          );
+          await settleHomeHero(page);
+        }
+        if (width === 320) {
+          await page.emulateMedia({ reducedMotion: "reduce" });
+          const hero = page.locator("likftc-filter-vortex-stage");
+          await hero.getByRole("button", { name: "Change search query", exact: true }).click();
+          const reducedBeatState = await hero.evaluate((host) => {
+            const root = host.shadowRoot;
+            const orbit = root?.querySelector("[data-beat-orbit-tone]");
+            const trigger = root?.querySelector("[data-trigger-tone]");
+            if (!(orbit instanceof HTMLElement) || !(trigger instanceof HTMLElement)) {
+              throw new Error("Hero beat tone elements are missing");
+            }
+            return {
+              animationCount: orbit.getAnimations().length,
+              orbitTone: orbit.style.getPropertyValue("--orbit-tone"),
+              orbitToneIndex: orbit.dataset["toneIndex"],
+              triggerTone: trigger.style.getPropertyValue("--trigger-tone"),
+              triggerToneIndex: trigger.dataset["toneIndex"],
+            };
+          });
+          assert.equal(reducedBeatState.animationCount, 0);
+          assert.equal(reducedBeatState.orbitTone, reducedBeatState.triggerTone);
+          assert.equal(reducedBeatState.orbitToneIndex, reducedBeatState.triggerToneIndex);
+        }
         assert.deepEqual(
           await page.evaluate(() => {
             const style = getComputedStyle(document.documentElement);


### PR DESCRIPTION
## Summary

- synchronize the hero's middle orbit color with the center trigger on every beat
- add a subtle 560 ms orbit pulse without changing layout
- preserve color synchronization while suppressing the pulse for reduced motion
- cover full-motion and reduced-motion beat contracts in docs validation

## Verification

- `vp check`
- `vp run check:docs`
- `vp run @vp-tw/likftc-docs#build`
- `LIKFTC_SITE_WIDTH=320 node scripts/validate-docs.mjs --browser=chromium`
- `LIKFTC_SITE_WIDTH=1440 node scripts/validate-docs.mjs --browser=chromium`
- desktop and mobile screenshot review against the local preview

## Risk

Low. The new motion is isolated to the existing Shadow DOM hero, uses transform and opacity only, and is disabled under `prefers-reduced-motion: reduce`.
